### PR TITLE
Compress store files

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -5,9 +5,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 : ${PREFIX:="."}
 
 declare -a SRC
-SRC=(rng pairs store rill)
+SRC=(htable rng pairs store rill)
 
 CFLAGS="-g -O3 -march=native -pipe -std=gnu11 -D_GNU_SOURCE"
+CFLAGS="$CFLAGS -I${PREFIX}/src"
+
 CFLAGS="$CFLAGS -Werror -Wall -Wextra"
 CFLAGS="$CFLAGS -Wundef -Wcast-align -Wwrite-strings -Wunreachable-code -Wformat=2"
 CFLAGS="$CFLAGS -Wswitch-enum -Wswitch-default -Winit-self -Wno-strict-aliasing"
@@ -23,3 +25,6 @@ ar rcs librill.a $OBJ
 gcc -o rill_load "${PREFIX}/src/load.c" librill.a $CFLAGS
 gcc -o rill_query "${PREFIX}/src/query.c" librill.a $CFLAGS
 gcc -o rill_dump "${PREFIX}/src/dump.c" librill.a $CFLAGS
+
+gcc -o test_coder "${PREFIX}/test/coder_test.c" librill.a $CFLAGS
+./test_coder

--- a/compile.sh
+++ b/compile.sh
@@ -26,5 +26,5 @@ gcc -o rill_load "${PREFIX}/src/load.c" librill.a $CFLAGS
 gcc -o rill_query "${PREFIX}/src/query.c" librill.a $CFLAGS
 gcc -o rill_dump "${PREFIX}/src/dump.c" librill.a $CFLAGS
 
-gcc -o test_coder "${PREFIX}/test/coder_test.c" librill.a $CFLAGS
-./test_coder
+gcc -o test_coder "${PREFIX}/test/coder_test.c" librill.a $CFLAGS && ./test_coder
+gcc -o test_rill "${PREFIX}/test/rill_test.c" librill.a $CFLAGS && ./test_rill

--- a/src/coder.c
+++ b/src/coder.c
@@ -1,0 +1,299 @@
+/* coder.c
+   Rémi Attab (remi.attab@gmail.com), 10 Sep 2017
+   FreeBSD-style copyright and disclaimer apply
+*/
+
+// -----------------------------------------------------------------------------
+// leb128
+// -----------------------------------------------------------------------------
+
+static inline uint8_t *leb128_encode(uint8_t *it, uint64_t val)
+{
+    static const size_t shift = 7;
+    static const uint64_t more_mask = 1UL << shift;
+    static const uint64_t body_mask = (1UL << shift) - 1;
+
+    do {
+        *it = val & body_mask;
+        *it |= (val >>= shift) ? more_mask : 0;
+        it++;
+    } while (val);
+
+    return it;
+}
+
+static inline bool leb128_decode(uint8_t **it, uint8_t *end, uint64_t *val)
+{
+    static const size_t shift = 7;
+    static const uint64_t more_mask = 1UL << shift;
+    static const uint64_t body_mask = (1UL << shift) - 1;
+
+    if (*it == end) return it;
+
+    uint8_t data;
+    size_t pos = 0;
+    *val = 0;
+
+    do {
+        data = **it; (*it)++;
+        *val |= (data & body_mask) << pos;
+        pos += shift;
+    } while ((data & more_mask) && *it != end);
+
+    return !(data & more_mask);
+}
+
+
+// -----------------------------------------------------------------------------
+// vals
+// -----------------------------------------------------------------------------
+
+struct rill_packed vals
+{
+    uint64_t len;
+    uint64_t data[];
+};
+
+typedef struct htable vals_rev_t;
+
+static rill_val_t vals_itov(struct vals *vals, size_t index)
+{
+    assert(index <= vals->len);
+    return vals->data[index - 1];
+}
+
+static size_t vals_vtoi(vals_rev_t *rev, rill_val_t val)
+{
+    if (!val) return 0; // \todo giant hack for coder_finish
+
+    struct htable_ret ret = htable_get(rev, val);
+    assert(ret.ok);
+    return ret.value;
+}
+
+static void vals_rev_make(struct vals *vals, vals_rev_t *rev)
+{
+    htable_reset(rev);
+    htable_reserve(rev, vals->len);
+
+    for (size_t index = 1; index <= vals->len; ++index) {
+        struct htable_ret ret = htable_put(rev, vals->data[index-1], index);
+        assert(ret.ok);
+    }
+}
+
+static int val_cmp(const void *l, const void *r)
+{
+    rill_val_t lhs = *((rill_val_t *) l);
+    rill_val_t rhs = *((rill_val_t *) r);
+
+    if (lhs < rhs) return -1;
+    if (lhs > rhs) return 1;
+    return 0;
+}
+
+static void vals_compact(struct vals *vals)
+{
+    assert(vals->len);
+    qsort(vals->data, vals->len, sizeof(vals->data[0]), &val_cmp);
+
+    size_t j = 0;
+    for (size_t i = 1; i < vals->len; ++i) {
+        if (vals->data[j] == vals->data[i]) continue;
+        vals->data[++j] = vals->data[i];
+    }
+
+    assert(j + 1 <= vals->len);
+    vals->len = j + 1;
+}
+
+static struct vals *vals_from_pairs(struct rill_pairs *pairs)
+{
+    struct vals *vals =
+        calloc(1, sizeof(*vals) + sizeof(vals->data[0]) * pairs->len);
+    if (!vals) return NULL;
+
+    vals->len = pairs->len;
+    for (size_t i = 0; i < pairs->len; ++i)
+        vals->data[i] = pairs->data[i].val;
+
+    vals_compact(vals);
+    return vals;
+}
+
+static struct vals *vals_merge(struct vals *vals, struct vals *merge)
+{
+    if (!vals) {
+        size_t len = sizeof(*vals) + sizeof(vals->data[0]) * merge->len;
+        vals = calloc(1, len);
+        memcpy(vals, merge, len);
+        return vals;
+    }
+
+    vals = realloc(vals,
+            sizeof(*vals) + sizeof(vals->data[0]) * (vals->len + merge->len));
+    if (!vals) return NULL;
+
+    memcpy( vals->data + vals->len,
+            merge->data,
+            sizeof(merge->data[0]) * merge->len);
+    vals->len += merge->len;
+
+    vals_compact(vals);
+    return vals;
+}
+
+
+// -----------------------------------------------------------------------------
+// coder
+// -----------------------------------------------------------------------------
+
+static const size_t coder_max_val_len = sizeof(rill_val_t) + 2 + 1;
+
+struct coder
+{
+    struct vals *vals;
+    vals_rev_t rev;
+
+    rill_key_t key;
+    uint8_t *it;
+    uint8_t *end;
+
+    size_t keys;
+    size_t pairs;
+};
+
+// -----------------------------------------------------------------------------
+// encode
+// -----------------------------------------------------------------------------
+
+static inline bool coder_write_sep(struct coder *coder)
+{
+    if (rill_unlikely(coder->it + 1 > coder->end)) return false;
+
+    *coder->it = 0;
+    coder->it++;
+
+    return true;
+}
+
+static inline bool coder_write_key(struct coder *coder, rill_key_t key)
+{
+    if (rill_unlikely(coder->it + sizeof(key) > coder->end)) return false;
+
+    memcpy(coder->it, &key, sizeof(key));
+    coder->it += sizeof(key);
+
+    return true;
+}
+
+static inline bool coder_write_val(struct coder *coder, rill_val_t val)
+{
+    val = vals_vtoi(&coder->rev, val);
+
+    uint8_t buffer[coder_max_val_len];
+    size_t len = leb128_encode(buffer, val) - buffer;
+
+    if (rill_unlikely(coder->it + len > coder->end)) return false;
+
+    memcpy(coder->it, buffer, len);
+    coder->it += len;
+
+    return true;
+}
+
+static bool coder_encode(struct coder *coder, const struct rill_kv *kv)
+{
+    if (coder->key != kv->key) {
+        if (rill_likely(coder->key)) {
+            if (!coder_write_sep(coder)) return false;
+        }
+
+        coder->key = kv->key;
+        if (!coder_write_key(coder, kv->key)) return false;
+        coder->keys++;
+    }
+
+    if (!coder_write_val(coder, kv->val)) return false;
+
+    coder->pairs++;
+    return true;
+}
+
+static bool coder_finish(struct coder *coder)
+{
+    if (!coder_write_sep(coder)) return false;
+    if (!coder_write_key(coder, 0)) return false;
+
+    htable_reset(&coder->rev);
+    return true;
+}
+
+static struct coder make_encoder(struct vals *vals, uint8_t *it, uint8_t *end)
+{
+    struct coder coder = {
+        .vals = vals,
+        .it = it,
+        .end = end,
+    };
+
+    vals_rev_make(coder.vals, &coder.rev);
+    return coder;
+}
+
+
+// -----------------------------------------------------------------------------
+// decode
+// -----------------------------------------------------------------------------
+
+static inline bool coder_read_key(struct coder *coder, rill_key_t *key)
+{
+    if (rill_unlikely(coder->it + sizeof(*key) > coder->end)) {
+        fail("unable to decode key: %p + %lu = %p > %p'\n",
+                (void *) coder->it, sizeof(*key),
+                (void *) (coder->it + sizeof(*key)),
+                (void *) coder->end);
+        return false;
+    }
+
+    memcpy(key, coder->it, sizeof(*key));
+    coder->it += sizeof(*key);
+
+    return true;
+}
+
+static inline bool coder_read_val(struct coder *coder, rill_val_t *val)
+{
+    if (!leb128_decode(&coder->it, coder->end, val)) {
+        fail("unable to decode value at '%p-%p'\n",
+                (void *) coder->it, (void *) coder->end);
+        return false;
+    }
+
+    if (*val) *val = vals_itov(coder->vals, *val);
+    return true;
+}
+
+static bool coder_decode(struct coder *coder, struct rill_kv *kv)
+{
+    if (rill_likely(coder->key)) {
+        kv->key = coder->key;
+        if (!coder_read_val(coder, &kv->val)) return false;
+        if (kv->val) return true;
+    }
+
+    if (!coder_read_key(coder, &coder->key)) return false;
+    kv->key = coder->key;
+    if (!kv->key) return true; // eof
+
+    return coder_read_val(coder, &kv->val);
+}
+
+static struct coder make_decoder(struct vals *vals, uint8_t *it, uint8_t *end)
+{
+    return (struct coder) {
+        .vals = vals,
+        .it = it,
+        .end = end,
+    };
+}

--- a/src/htable.c
+++ b/src/htable.c
@@ -1,0 +1,142 @@
+/* htable.c
+   Rémi Attab (remi.attab@gmail.com), 10 Mar 2016
+   FreeBSD-style copyright and disclaimer apply
+*/
+
+#include "htable.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+// -----------------------------------------------------------------------------
+// config
+// -----------------------------------------------------------------------------
+
+enum { probe_window = 8 };
+
+
+// -----------------------------------------------------------------------------
+// hash
+// -----------------------------------------------------------------------------
+
+// FNV-1a hash implementation: http://isthe.com/chongo/tech/comp/fnv/
+inline uint64_t hash_key(uint64_t key)
+{
+    const uint8_t *data = (uint8_t *) &key;
+
+    uint64_t hash = 0xcbf29ce484222325;
+    for (size_t i = 0; i < sizeof(key); ++i)
+        hash = (hash ^ data[i]) * 0x100000001b3;
+
+    assert(hash); // \todo Can't be 0
+    return hash;
+}
+
+
+// -----------------------------------------------------------------------------
+// htable
+// -----------------------------------------------------------------------------
+
+void htable_reset(struct htable *ht)
+{
+    free(ht->table);
+    *ht = (struct htable) {0};
+}
+
+static bool table_put(
+        struct htable_bucket *table, size_t cap,
+        uint64_t key, uint64_t value)
+{
+    assert(key);
+    uint64_t hash = hash_key(key);
+
+    for (size_t i = 0; i < probe_window; ++i) {
+        struct htable_bucket *bucket = &table[(hash + i) % cap];
+        if (bucket->key) continue;
+
+        bucket->key = key;
+        bucket->value = value;
+        return true;
+    }
+
+    return false;
+}
+
+static void htable_resize(struct htable *ht, size_t cap)
+{
+    if (cap <= ht->cap) return;
+
+    size_t new_cap = ht->cap ? ht->cap : 1;
+    while (new_cap < cap) new_cap *= 2;
+
+    struct htable_bucket *new_table = calloc(new_cap, sizeof(*new_table));
+    for (size_t i = 0; i < ht->cap; ++i) {
+        struct htable_bucket *bucket = &ht->table[i];
+        if (!bucket->key) continue;
+
+        if (!table_put(new_table, new_cap, bucket->key, bucket->value)) {
+            free(new_table);
+            htable_resize(ht, new_cap * 2);
+            return;
+        }
+    }
+
+    free(ht->table);
+    ht->cap = new_cap;
+    ht->table = new_table;
+}
+
+void htable_reserve(struct htable *ht, size_t items)
+{
+    htable_resize(ht, items * 4);
+}
+
+
+// -----------------------------------------------------------------------------
+// ops
+// -----------------------------------------------------------------------------
+
+struct htable_ret htable_get(struct htable *ht, uint64_t key)
+{
+    assert(key);
+
+    uint64_t hash = hash_key(key);
+    htable_resize(ht, probe_window);
+
+    for (size_t i = 0; i < probe_window; ++i) {
+        struct htable_bucket *bucket = &ht->table[(hash + i) % ht->cap];
+
+        if (!bucket->key) continue;
+        if (bucket->key != key) continue;
+
+        return (struct htable_ret) { .ok = true, .value = bucket->value };
+    }
+
+    return (struct htable_ret) { .ok = false };
+}
+
+struct htable_ret htable_put(struct htable *ht, uint64_t key, uint64_t value)
+{
+    assert(key);
+
+    uint64_t hash = hash_key(key);
+    htable_resize(ht, probe_window);
+
+    for (size_t i = 0; i < probe_window; ++i) {
+        struct htable_bucket *bucket = &ht->table[(hash + i) % ht->cap];
+
+        if (bucket->key) {
+            if (bucket->key != key) continue;
+            return (struct htable_ret) { .ok = false, .value = bucket->value };
+        }
+
+        ht->len++;
+        bucket->key = key;
+        bucket->value = value;
+        return (struct htable_ret) { .ok = true };
+    }
+
+    htable_resize(ht, ht->cap * 2);
+    return htable_put(ht, key, value);
+}

--- a/src/htable.h
+++ b/src/htable.h
@@ -1,0 +1,40 @@
+/* htable.h
+   Rémi Attab (remi.attab@gmail.com), 10 Mar 2016
+   FreeBSD-style copyright and disclaimer apply
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+
+// -----------------------------------------------------------------------------
+// struct
+// -----------------------------------------------------------------------------
+
+struct htable_bucket
+{
+    uint64_t key;
+    uint64_t value;
+};
+
+struct htable
+{
+    size_t len;
+    size_t cap;
+    struct htable_bucket *table;
+};
+
+struct htable_ret
+{
+    bool ok;
+    uint64_t value;
+};
+
+
+void htable_reset(struct htable *);
+void htable_reserve(struct htable *, size_t items);
+struct htable_ret htable_get(struct htable *, uint64_t key);
+struct htable_ret htable_put(struct htable *, uint64_t key, uint64_t value);

--- a/src/load.c
+++ b/src/load.c
@@ -49,22 +49,22 @@ int main(int argc, char **argv)
     if (!db) return 1;
 
     enum {
-        keys_per_sec = 10 * 1000,
+        keys_per_sec = 1 * 1000,
         seconds = 3 * 31 * 24 * 60 * 60,
 
         keys_range = 1 * 1000 * 1000 * 1000,
-        vals_range = 1 * 1000,
+        vals_range = 10 * 1000,
         vals_per_key = 4,
     };
 
     struct rng rng = rng_make(0);
     for (size_t ts = 0; ts < seconds; ++ts) {
         for (size_t i = 0; i < keys_per_sec; ++i) {
-            uint64_t key = rng_gen_val(&rng, ts, keys_range);
+            uint64_t key = rng_gen_val(&rng, 0, keys_range);
 
             for (size_t j = 0; j < vals_per_key; ++j) {
-                uint64_t val = rng_gen_val(&rng, ts, vals_range);
-                if (!rill_ingest(db, ts, key, val)) return 1;
+                uint64_t val = rng_gen_val(&rng, 0, vals_range);
+                if (!rill_ingest(db, key, val)) return 1;
             }
         }
 

--- a/src/load.c
+++ b/src/load.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
     if (!db) return 1;
 
     enum {
-        keys_per_sec = 1 * 1000,
+        keys_per_sec = 200,
         seconds = 3 * 31 * 24 * 60 * 60,
 
         keys_range = 1 * 1000 * 1000 * 1000,

--- a/src/pairs.c
+++ b/src/pairs.c
@@ -17,7 +17,6 @@
 void rill_pairs_free(struct rill_pairs *pairs)
 {
     free(pairs->data);
-    free(pairs);
 }
 
 static bool resize(struct rill_pairs *pairs, size_t len)

--- a/src/pairs.c
+++ b/src/pairs.c
@@ -4,6 +4,7 @@
 */
 
 #include "rill.h"
+#include "utils.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,41 +15,52 @@
 // pairs
 // -----------------------------------------------------------------------------
 
+static size_t adjust_cap(size_t cap, size_t len)
+{
+    while (len > cap) cap *= 2;
+    return cap;
+}
+
+struct rill_pairs *rill_pairs_new(size_t cap)
+{
+    cap = adjust_cap(1, cap);
+
+    struct rill_pairs *pairs =
+        calloc(1, sizeof(*pairs) + cap * sizeof(pairs->data[0]));
+    if (!pairs) return NULL;
+
+    pairs->cap = cap;
+    return pairs;
+}
+
+
 void rill_pairs_free(struct rill_pairs *pairs)
 {
-    free(pairs->data);
+    free(pairs);
 }
 
-static bool resize(struct rill_pairs *pairs, size_t len)
-{
-    if (len <= pairs->cap) return true;
 
-    size_t cap = pairs->cap ? pairs->cap : 16;
-    while (cap < len) cap *= 2;
-
-    void *ret = realloc(pairs->data, cap * sizeof(*pairs->data));
-    if (!ret) return false;
-
-    pairs->data = ret;
-    pairs->cap = cap;
-
-    return true;
-}
-
-bool rill_pairs_reset(struct rill_pairs *pairs, size_t cap)
+void rill_pairs_clear(struct rill_pairs *pairs)
 {
     pairs->len = 0;
-    return resize(pairs, cap);
 }
 
-bool rill_pairs_push(struct rill_pairs *pairs, rill_key_t key, rill_val_t val)
+struct rill_pairs *rill_pairs_push(
+        struct rill_pairs *pairs, rill_key_t key, rill_val_t val)
 {
-    if (!resize(pairs, pairs->len + 1)) return false;
+    if (rill_unlikely(pairs->len + 1 > pairs->cap)) {
+        size_t cap = adjust_cap(pairs->cap, pairs->len + 1);
+
+        pairs = realloc(pairs, sizeof(*pairs) + cap * sizeof(pairs->data[0]));
+        if (!pairs) return NULL;
+
+        pairs->cap = cap;
+    }
 
     pairs->data[pairs->len] = (struct rill_kv) { .key = key, .val = val };
     pairs->len++;
 
-    return true;
+    return pairs;
 }
 
 static int kv_cmp(const void *lhs, const void *rhs)
@@ -72,38 +84,46 @@ void rill_pairs_compact(struct rill_pairs *pairs)
     pairs->len = j + 1;
 }
 
-bool rill_pairs_scan_key(
+struct rill_pairs *rill_pairs_scan_key(
         const struct rill_pairs *pairs,
         const rill_key_t *keys, size_t len,
         struct rill_pairs *out)
 {
+    struct rill_pairs *result = out;
+
     for (size_t i = 0; i < pairs->len; ++i) {
-        struct rill_kv *kv = &pairs->data[i];
+        const struct rill_kv *kv = &pairs->data[i];
 
         for (size_t j = 0; j < len; ++j) {
             if (kv->key != keys[j]) continue;
-            if (!rill_pairs_push(out, kv->key, kv->val)) return false;
+
+            result = rill_pairs_push(result, kv->key, kv->val);
+            if (!result) return NULL;
         }
     }
 
-    return true;
+    return result;
 }
 
-bool rill_pairs_scan_val(
+struct rill_pairs *rill_pairs_scan_val(
         const struct rill_pairs *pairs,
         const rill_val_t *vals, size_t len,
         struct rill_pairs *out)
 {
+    struct rill_pairs *result = out;
+
     for (size_t i = 0; i < pairs->len; ++i) {
-        struct rill_kv *kv = &pairs->data[i];
+        const struct rill_kv *kv = &pairs->data[i];
 
         for (size_t j = 0; j < len; ++j) {
             if (kv->val != vals[j]) continue;
-            if (!rill_pairs_push(out, kv->key, kv->val)) return false;
+
+            result = rill_pairs_push(result, kv->key, kv->val);
+            if (!result) return NULL;
         }
     }
 
-    return true;
+    return result;
 }
 
 void rill_pairs_print(const struct rill_pairs *pairs)
@@ -111,16 +131,18 @@ void rill_pairs_print(const struct rill_pairs *pairs)
     const rill_key_t no_key = -1ULL;
     rill_key_t key = no_key;
 
+    printf("pairs(%p, %lu, %lu):\n", (void *) pairs, pairs->len, pairs->cap);
+
     for (size_t i = 0; i < pairs->len; ++i) {
-        struct rill_kv *kv = &pairs->data[i];
+        const struct rill_kv *kv = &pairs->data[i];
 
         if (kv->key == key) fprintf(stderr, ", %lu", kv->val);
         else {
             if (key != no_key) fprintf(stderr, "]\n");
-            fprintf(stderr, "%p: [ %lu", (void *) kv->key, kv->val);
+            fprintf(stderr, "  %p: [ %lu", (void *) kv->key, kv->val);
             key = kv->key;
         }
     }
 
-    fprintf(stderr, " ]\n");
+    if (pairs->len) fprintf(stderr, " ]\n");
 }

--- a/src/rill.c
+++ b/src/rill.c
@@ -16,6 +16,14 @@
 
 
 // -----------------------------------------------------------------------------
+// kv
+// -----------------------------------------------------------------------------
+
+extern inline bool rill_kv_nil(const struct rill_kv *);
+extern inline int rill_kv_cmp(const struct rill_kv *, const struct rill_kv *);
+
+
+// -----------------------------------------------------------------------------
 // config
 // -----------------------------------------------------------------------------
 
@@ -95,26 +103,14 @@ struct rill * rill_open(const char *dir)
         goto fail_alloc_dir;
     }
 
-    db->acc = calloc(1, sizeof(*db->acc));
-    if (!db->acc) {
-        fail("unable to allocate memory for '%s'", dir);
+    if (!(db->acc = rill_pairs_new(1 * 1000 * 1000))) {
+        fail("unable to allocate pairs for '%s'", dir);
         goto fail_alloc_acc;
     }
 
-    db->dump = calloc(1, sizeof(*db->dump));
-    if (!db->dump) {
-        fail("unable to allocate memory for '%s'", dir);
+    if (!(db->dump = rill_pairs_new(1 * 1000 * 1000))) {
+        fail("unable to allocate pairs for '%s'", dir);
         goto fail_alloc_dump;
-    }
-
-    if (!rill_pairs_reset(db->acc, 1 *1000 * 1000)) {
-        fail("unable to allocate pairs for '%s'", dir);
-        goto fail_pairs;
-    }
-
-    if (!rill_pairs_reset(db->dump, 1 *1000 * 1000)) {
-        fail("unable to allocate pairs for '%s'", dir);
-        goto fail_pairs;
     }
 
     if (mkdir(dir, 0775) == -1 && errno != EEXIST) {
@@ -150,12 +146,9 @@ struct rill * rill_open(const char *dir)
     closedir(dir_handle);
   fail_dir:
   fail_mkdir:
-  fail_pairs:
     rill_pairs_free(db->dump);
-    free(db->dump);
   fail_alloc_dump:
     rill_pairs_free(db->acc);
-    free(db->acc);
   fail_alloc_acc:
     free((char *) db->dir);
   fail_alloc_dir:
@@ -178,12 +171,10 @@ void rill_close(struct rill *db)
         if (db->monthly[i]) rill_store_close(db->monthly[i]);
     }
 
-    rill_pairs_free(db->acc);
-    rill_pairs_free(db->dump);
 
     free((char *) db->dir);
-    free(db->dump);
-    free(db->acc);
+    rill_pairs_free(db->acc);
+    rill_pairs_free(db->dump);
     free(db);
 }
 
@@ -204,16 +195,17 @@ bool rill_ingest(struct rill *db, rill_key_t key, rill_val_t val)
         return false;
     }
 
-    bool ret;
+    struct rill_pairs *result;
     {
         lock(&db->lock);
 
-        ret = rill_pairs_push(db->acc, key, val);
+        result = rill_pairs_push(db->acc, key, val);
 
         unlock(&db->lock);
     }
 
-    return ret;
+    if (result) db->acc = result;
+    return result != NULL;
 }
 
 
@@ -240,6 +232,11 @@ static bool rotate_monthly(
         (void) rill_store_rm(*store);
         *store = NULL;
     }
+
+    bool all_null = true;
+    for (size_t i = 0; i < len; ++i) all_null = all_null && !list[i];
+    if (all_null) return true;
+
     if (!rill_store_merge(file, ts, quant_month, list, len)) return false;
     if (!(*store = rill_store_open(file))) return false;
 
@@ -264,6 +261,11 @@ static bool rotate_daily(
             (ts / quant_day) % days);
 
     assert(!*store);
+
+    bool all_null = true;
+    for (size_t i = 0; i < len; ++i) all_null = all_null && !list[i];
+    if (all_null) return true;
+
     if (!rill_store_merge(file, ts, quant_day, list, len)) return false;
     if (!(*store = rill_store_open(file))) return false;
 
@@ -300,7 +302,7 @@ static bool rotate_hourly(struct rill *db, struct rill_store **store, rill_ts_t 
         if (!(*store = rill_store_open(file))) return false;
     }
 
-    rill_pairs_reset(db->dump, db->dump->cap);
+    rill_pairs_clear(db->dump);
     return true;
 }
 
@@ -339,42 +341,62 @@ bool rill_rotate(struct rill *db, rill_ts_t now)
 // query
 // -----------------------------------------------------------------------------
 
-void rill_query_key(struct rill *db, rill_key_t *keys, size_t len, struct rill_pairs *out)
+struct rill_pairs *rill_query_key(
+        struct rill *db,
+        const rill_key_t *keys, size_t len,
+        struct rill_pairs *out)
 {
+    struct rill_pairs *result = out;
+    if (!len) return result;
+
     for (size_t i = 0; i < hours; ++i) {
         if (!db->hourly[i]) continue;
-        rill_store_scan_key(db->hourly[i], keys, len, out);
+        result = rill_store_scan_key(db->hourly[i], keys, len, result);
+        if (!result) return NULL;
     }
 
     for (size_t i = 0; i < days; ++i) {
         if (!db->daily[i]) continue;
-        rill_store_scan_key(db->daily[i], keys, len, out);
+        result = rill_store_scan_key(db->daily[i], keys, len, result);
+        if (!result) return NULL;
     }
 
     for (size_t i = 0; i < months; ++i) {
         if (!db->monthly[i]) continue;
-        rill_store_scan_key(db->monthly[i], keys, len, out);
+        result = rill_store_scan_key(db->monthly[i], keys, len, result);
+        if (!result) return NULL;
     }
 
-    rill_pairs_compact(out);
+    rill_pairs_compact(result);
+    return result;
 }
 
-void rill_query_val(struct rill *db, rill_val_t *vals, size_t len, struct rill_pairs *out)
+struct rill_pairs *rill_query_val(
+        struct rill *db,
+        const rill_val_t *vals, size_t len,
+        struct rill_pairs *out)
 {
+    struct rill_pairs *result = out;
+    if (!len) return result;
+
     for (size_t i = 0; i < hours; ++i) {
         if (!db->hourly[i]) continue;
-        rill_store_scan_val(db->hourly[i], vals, len, out);
+        result = rill_store_scan_val(db->hourly[i], vals, len, result);
+        if (!result) return result;
     }
 
     for (size_t i = 0; i < days; ++i) {
         if (!db->daily[i]) continue;
-        rill_store_scan_val(db->daily[i], vals, len, out);
+        result = rill_store_scan_val(db->daily[i], vals, len, result);
+        if (!result) return result;
     }
 
     for (size_t i = 0; i < months; ++i) {
         if (!db->monthly[i]) continue;
-        rill_store_scan_val(db->monthly[i], vals, len, out);
+        result = rill_store_scan_val(db->monthly[i], vals, len, result);
+        if (!result) return result;
     }
 
-    rill_pairs_compact(out);
+    rill_pairs_compact(result);
+    return result;
 }

--- a/src/rill.h
+++ b/src/rill.h
@@ -22,13 +22,16 @@ typedef uint64_t rill_val_t;
 // kv
 // -----------------------------------------------------------------------------
 
-#define rill_packed __attribute__((__packed__))
-
-struct rill_packed rill_kv
+struct rill_kv
 {
     rill_key_t key;
     rill_val_t val;
 };
+
+static inline bool rill_kv_nil(const struct rill_kv *kv)
+{
+    return !kv->key && !kv->val;
+}
 
 static inline int rill_kv_cmp(const struct rill_kv *lhs, const struct rill_kv *rhs)
 {
@@ -118,7 +121,7 @@ struct rill;
 struct rill * rill_open(const char *dir);
 void rill_close(struct rill *db);
 
-bool rill_ingest(struct rill *db, rill_ts_t now, rill_key_t key, rill_val_t val);
+bool rill_ingest(struct rill *db, rill_key_t key, rill_val_t val);
 bool rill_rotate(struct rill *db, rill_ts_t now);
 
 void rill_query_key(struct rill *db, rill_key_t *keys, size_t len, struct rill_pairs *out);

--- a/src/rill.h
+++ b/src/rill.h
@@ -28,12 +28,12 @@ struct rill_kv
     rill_val_t val;
 };
 
-static inline bool rill_kv_nil(const struct rill_kv *kv)
+inline bool rill_kv_nil(const struct rill_kv *kv)
 {
     return !kv->key && !kv->val;
 }
 
-static inline int rill_kv_cmp(const struct rill_kv *lhs, const struct rill_kv *rhs)
+inline int rill_kv_cmp(const struct rill_kv *lhs, const struct rill_kv *rhs)
 {
     if (lhs->key < rhs->key) return -1;
     if (lhs->key > rhs->key) return +1;
@@ -52,20 +52,24 @@ static inline int rill_kv_cmp(const struct rill_kv *lhs, const struct rill_kv *r
 struct rill_pairs
 {
     size_t len, cap;
-    struct rill_kv *data;
+    struct rill_kv data[];
 };
 
+struct rill_pairs *rill_pairs_new(size_t cap);
 void rill_pairs_free(struct rill_pairs *pairs);
-bool rill_pairs_reset(struct rill_pairs *pairs, size_t cap);
-bool rill_pairs_push(struct rill_pairs *pairs, rill_key_t key, rill_val_t val);
+void rill_pairs_clear(struct rill_pairs *pairs);
+
+struct rill_pairs *rill_pairs_push(
+        struct rill_pairs *pairs, rill_key_t key, rill_val_t val);
+
 void rill_pairs_compact(struct rill_pairs *pairs);
 
-bool rill_pairs_scan_key(
+struct rill_pairs *rill_pairs_scan_key(
         const struct rill_pairs *pairs,
         const rill_key_t *keys, size_t len,
         struct rill_pairs *out);
 
-bool rill_pairs_scan_val(
+struct rill_pairs *rill_pairs_scan_val(
         const struct rill_pairs *pairs,
         const rill_val_t *vals, size_t len,
         struct rill_pairs *out);
@@ -99,11 +103,11 @@ const char * rill_store_file(struct rill_store *store);
 rill_ts_t rill_store_ts(struct rill_store *store);
 size_t rill_store_quant(struct rill_store *store);
 
-bool rill_store_scan_key(
+struct rill_pairs *rill_store_scan_key(
         struct rill_store *store,
         const rill_key_t *keys, size_t len,
         struct rill_pairs *out);
-bool rill_store_scan_val(
+struct rill_pairs *rill_store_scan_val(
         struct rill_store *store,
         const rill_val_t *vals, size_t len,
         struct rill_pairs *out);
@@ -124,5 +128,12 @@ void rill_close(struct rill *db);
 bool rill_ingest(struct rill *db, rill_key_t key, rill_val_t val);
 bool rill_rotate(struct rill *db, rill_ts_t now);
 
-void rill_query_key(struct rill *db, rill_key_t *keys, size_t len, struct rill_pairs *out);
-void rill_query_val(struct rill *db, rill_val_t *vals, size_t len, struct rill_pairs *out);
+struct rill_pairs *rill_query_key(
+        struct rill *db,
+        const rill_key_t *keys, size_t len,
+        struct rill_pairs *out);
+
+struct rill_pairs *rill_query_val(
+        struct rill *db,
+        const rill_val_t *vals, size_t len,
+        struct rill_pairs *out);

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,23 +6,39 @@
 #pragma once
 
 
-#include <stdio.h>
-#include <string.h>
 #include <errno.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
 #include <stdatomic.h>
+
+
+// -----------------------------------------------------------------------------
+// attributes
+// -----------------------------------------------------------------------------
+
+#define rill_packed       __attribute__((__packed__))
+#define rill_likely(x)    __builtin_expect(x, 1)
+#define rill_unlikely(x)  __builtin_expect(x, 0)
+
+
+// -----------------------------------------------------------------------------
+// misc
+// -----------------------------------------------------------------------------
+
+enum { page_len_s = 4096 };
+static const size_t page_len = page_len_s;
 
 
 // -----------------------------------------------------------------------------
 // err
 // -----------------------------------------------------------------------------
 
-
 #define fail(fmt, ...) \
     fprintf(stderr, "[fail] "fmt"\n", __VA_ARGS__)
 
 #define fail_errno(fmt, ...) \
     fprintf(stderr, "[fail] "fmt"(%d): %s\n", __VA_ARGS__, errno, strerror(errno))
-
 
 // -----------------------------------------------------------------------------
 // lock

--- a/test/coder_test.c
+++ b/test/coder_test.c
@@ -1,0 +1,224 @@
+/* coder_test.c
+   Rémi Attab (remi.attab@gmail.com), 11 Sep 2017
+   FreeBSD-style copyright and disclaimer apply
+*/
+
+#include "test.h"
+
+#include "coder.c"
+
+
+// -----------------------------------------------------------------------------
+// leb128
+// -----------------------------------------------------------------------------
+
+static void check_leb128(uint64_t val)
+{
+    uint8_t data[10] = {0};
+
+    {
+        uint8_t *it = leb128_encode(data, val);
+        size_t len = (uintptr_t) it - (uintptr_t) data;
+             if (val < (1UL <<  7)) assert(len == 1);
+        else if (val < (1UL << 14)) assert(len == 2);
+        else if (val < (1UL << 21)) assert(len == 3);
+        else if (val < (1UL << 28)) assert(len == 4);
+        else if (val < (1UL << 35)) assert(len == 5);
+        else if (val < (1UL << 42)) assert(len == 6);
+        else if (val < (1UL << 49)) assert(len == 7);
+        else if (val < (1UL << 56)) assert(len == 8);
+        else if (val < (1UL << 63)) assert(len == 9);
+        else                        assert(len == 10);
+    }
+
+    {
+        uint8_t *it = data;
+        uint64_t result = 0;
+        assert(leb128_decode(&it, it + sizeof(data), &result));
+        assert(val == result);
+    }
+}
+
+bool test_leb128(void)
+{
+    check_leb128(0);
+    for (size_t i = 0; i < 64; ++i) check_leb128(1UL << i);
+
+    struct rng rng = rng_make(0);
+    for (size_t i = 0; i < 64; ++i) {
+        for (size_t j = 0; j < 100; ++j)
+            check_leb128(rng_gen_range(&rng, 0, 1UL << i));
+    }
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// vals
+// -----------------------------------------------------------------------------
+
+#define make_vals(...)                                          \
+    ({                                                          \
+        rill_val_t vals[] = { __VA_ARGS__ };                    \
+        make_vals_impl(vals, sizeof(vals) / sizeof(vals[0]));   \
+    })
+
+static struct vals *make_vals_impl(rill_val_t *list, size_t len)
+{
+    struct vals *vals = calloc(1, sizeof(struct vals) + sizeof(list[0]) * len);
+
+    vals->len = len;
+    for (size_t i = 0; i < len; ++i) vals->data[i] = list[i];
+
+    vals_compact(vals);
+    return vals;
+}
+
+static void check_vals(struct rill_pairs pairs, struct vals *exp)
+{
+    struct vals *vals = vals_from_pairs(&pairs);
+
+    assert(vals->len == exp->len);
+    for (size_t i = 0; i < exp->len; ++i)
+        assert(vals->data[i] == exp->data[i]);
+
+    vals_rev_t rev = {0};
+    vals_rev_make(vals, &rev);
+
+    for (size_t i = 0; i < exp->len; ++i) {
+        size_t index = vals_vtoi(&rev, exp->data[i]);
+        assert(vals_itov(vals, index) == exp->data[i]);
+    }
+
+    free(vals);
+    free(exp);
+}
+
+static void check_vals_merge(struct vals *a, struct vals *b, struct vals *exp)
+{
+    struct vals *result = vals_merge(a, b);
+
+    assert(result->len == exp->len);
+    for (size_t i = 0; i < exp->len; ++i)
+        assert(result->data[i] == exp->data[i]);
+
+    free(a);
+    free(b);
+}
+
+bool test_vals(void)
+{
+    check_vals(make_pair(kv(1, 10)), make_vals(10));
+
+    check_vals(make_pair(kv(1, 10), kv(1, 10)), make_vals(10));
+    check_vals(make_pair(kv(1, 10), kv(2, 10)), make_vals(10));
+
+    check_vals(make_pair(kv(1, 10), kv(1, 20)), make_vals(10, 20));
+    check_vals(make_pair(kv(1, 10), kv(2, 20)), make_vals(10, 20));
+
+    check_vals(make_pair(kv(2, 20), kv(1, 10)), make_vals(10, 20));
+    check_vals(make_pair(kv(1, 20), kv(1, 10)), make_vals(10, 20));
+
+    check_vals_merge(make_vals(10), make_vals(10), make_vals(10));
+    check_vals_merge(make_vals(10), make_vals(20), make_vals(10, 20));
+
+    check_vals_merge(make_vals(10, 20), make_vals(20), make_vals(10, 20));
+    check_vals_merge(make_vals(10, 20), make_vals(20, 30), make_vals(10, 20, 30));
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// coder
+// -----------------------------------------------------------------------------
+
+void check_coder(struct rill_pairs pairs)
+{
+    rill_pairs_compact(&pairs);
+
+    size_t cap = (pairs.len + 1) * (sizeof(pairs.data[0]) + 3);
+    uint8_t *buffer = calloc(1, cap);
+    struct vals *vals = vals_from_pairs(&pairs);
+
+    size_t len = 0;
+    {
+        struct coder coder = make_encoder(vals, buffer, buffer + cap);
+        for (size_t i = 0; i < pairs.len; ++i)
+            assert(coder_encode(&coder, &pairs.data[i]));
+        assert(coder_finish(&coder));
+
+        len = coder.it - buffer;
+        assert(len <= cap);
+    }
+
+    /* printf("buffer: start=%p, len=%lu\n", (void *) buffer, len); */
+    /* for (size_t i = 0; i < cap;) { */
+    /*     printf("%6p: ", (void *) i); */
+    /*     for (size_t j = 0; j < 16 && i < cap; ++i, ++j) { */
+    /*         if (j % 2 == 0) printf(" "); */
+    /*         printf("%02x", buffer[i]); */
+    /*     } */
+    /*     printf("\n"); */
+    /* } */
+
+    {
+        struct coder coder = make_decoder(vals, buffer, buffer + len);
+
+        struct rill_kv kv = {0};
+        for (size_t i = 0; i < pairs.len; ++i) {
+            assert(coder_decode(&coder, &kv));
+            assert(rill_kv_cmp(&kv, &pairs.data[i]) == 0);
+        }
+
+        assert(coder_decode(&coder, &kv));
+        assert(rill_kv_nil(&kv));
+    }
+
+    free(vals);
+}
+
+
+bool test_coder(void)
+{
+    check_coder(make_pair(kv(1, 10)));
+    check_coder(make_pair(kv(1, 10), kv(1, 20)));
+    check_coder(make_pair(kv(1, 10), kv(2, 20)));
+    check_coder(make_pair(kv(1, 10), kv(1, 20), kv(2, 30)));
+    check_coder(make_pair(kv(1, 10), kv(1, 20), kv(2, 10)));
+
+    struct rng rng = rng_make(0);
+    for (size_t iterations = 0; iterations < 100; ++iterations) {
+
+        struct rill_pairs pairs = {0};
+        for (size_t i = 0; i < 1000; ++i) {
+            uint64_t key = rng_gen_range(&rng, 1, 500);
+            uint64_t val = rng_gen_range(&rng, 1, 100);
+            rill_pairs_push(&pairs, key, val);
+        }
+
+        check_coder(pairs);
+        rill_pairs_free(&pairs);
+    }
+
+    return true;
+}
+
+
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main(int argc, char **argv)
+{
+    (void) argc, (void) argv;
+    bool ret = true;
+
+    ret = ret && test_leb128();
+    ret = ret && test_vals();
+    ret = ret && test_coder();
+
+    return ret ? 0 : 1;
+}

--- a/test/rill_test.c
+++ b/test/rill_test.c
@@ -1,0 +1,75 @@
+/* rill_test.c
+   Rémi Attab (remi.attab@gmail.com), 13 Sep 2017
+   FreeBSD-style copyright and disclaimer apply
+*/
+
+#include "test.h"
+
+
+// -----------------------------------------------------------------------------
+// rotate
+// -----------------------------------------------------------------------------
+
+bool test_rotate(void)
+{
+    const char *dir = "test.rotate.db";
+
+    rm(dir);
+    struct rill *db = rill_open(dir);
+
+    const uint64_t key = 1;
+
+    for (rill_ts_t ts = 0; ts < 13 * month; ts += 1 * hour) {
+        rill_ingest(db, key, ts + 1);
+        rill_rotate(db, ts);
+    }
+    rill_rotate(db, 13 * month);
+
+    {
+        struct rill_pairs *pairs = rill_query_key(db, &key, 1, rill_pairs_new(1));
+
+        size_t i = 0;
+        for (rill_ts_t ts = 0; ts < 13 * month; ts += 1 * hour) {
+            assert(pairs->data[i].key == key);
+            assert(pairs->data[i].val == ts + 1);
+            ++i;
+        }
+
+        rill_pairs_free(pairs);
+    }
+
+    // \todo this is bad and doesn't properly expire things.
+    for (size_t i = 1; i <= 6; ++i)
+        rill_rotate(db, (13 + i) * month);
+
+    {
+        struct rill_pairs *pairs = rill_query_key(db, &key, 1, rill_pairs_new(1));
+
+        for (size_t i = 0; i < pairs->len; ++i) {
+            assert(pairs->data[i].key == key);
+            assert(pairs->data[i].val >= (5 * month) + 1);
+        }
+
+        rill_pairs_free(pairs);
+    }
+
+    rill_close(db);
+    rm(dir);
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main(int argc, char **argv)
+{
+    (void) argc, (void) argv;
+    bool ret = true;
+
+    ret = ret && test_rotate();
+
+    return ret ? 0 : 1;
+}

--- a/test/test.h
+++ b/test/test.h
@@ -1,0 +1,40 @@
+/* test.h
+   Rémi Attab (remi.attab@gmail.com), 11 Sep 2017
+   FreeBSD-style copyright and disclaimer apply
+*/
+
+#pragma once
+
+#include "rill.h"
+#include "utils.h"
+#include "htable.h"
+#include "rng.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+
+// -----------------------------------------------------------------------------
+// utils
+// -----------------------------------------------------------------------------
+
+struct rill_kv kv(rill_key_t key, rill_val_t val)
+{
+    return (struct rill_kv) { .key = key, .val = val };
+}
+
+#define make_pair(...)                                          \
+    ({                                                          \
+        struct rill_kv kvs[] = { __VA_ARGS__ };                 \
+        make_pair_impl(kvs, sizeof(kvs) / sizeof(kvs[0]));      \
+    })
+
+struct rill_pairs make_pair_impl(const struct rill_kv *kv, size_t len)
+{
+    struct rill_pairs pairs = {0};
+    for (size_t i = 0; i < len; ++i)
+        rill_pairs_push(&pairs, kv[i].key, kv[i].val);
+    return pairs;
+}


### PR DESCRIPTION
Implement a simple compression scheme for the store files which is based on the following assumptions:
- keys are uniformly distributed with a large cardinality
- values are of small cardinality
- keys will, on average, contain at least 4 values.

Given this, the compression scheme is as follow:
- Keys are not compressed (not much we could there anyway).
- Values for a key are grouped toghether which reduces the number of redundant keys written.
- Values are normalized in a table which indexes each value to a sequential id.
- normalized values are then encoded with leb128.

still working on evaluating the result of the compression scheme. The hope is that while it adds some overhead to database scans, it should also vastly reduce the number of pages that need to be fetched from disk and therefore make up for the slow down.